### PR TITLE
Update Microsoft package versions in OData.Server

### DIFF
--- a/CS/OData.Server/OData.Server.csproj
+++ b/CS/OData.Server/OData.Server.csproj
@@ -23,11 +23,11 @@
   <ItemGroup>
     <PackageReference Include="DevExpress.Drawing.Skia" Version="24.1.3" />
     <PackageReference Include="DevExpress.ExpressApp.Api.EFCore.All" Version="24.1.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="7.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.18" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- EF Core (SqlServer, InMemory, Proxies) 7.0.3 -> 8.0.18
- Authentication.JwtBearer 6.0.0 -> 8.0.18
- Swashbuckle.AspNetCore and Swashbuckle.AspNetCore.Annotations 6.5.0 -> 6.9.0

Previous pins were below the versions XAF requires from DX 25.1 onward, so NuGet restore failed with NU1605 package downgrade errors. The new versions satisfy both DX 25.1 (EF 8.0.11, JwtBearer 8.0.17) and DX 26.1 (EF 8.0.18).

DevExpress package versions and TargetFramework are unchanged: net8.0 stays correct across the whole 24.1.3+ to 26.1.4 range, since DX 26.1 declares a net8.0 dependency group only.